### PR TITLE
Allow for not setting default hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Run the tests by provisioning the appropriate VM:
 
 At the moment, `ubuntu-precise` is the only test VM available.
 
+This role will create a default config that will return 404 on all requests. If you do not want that,
+define nginx_default_site_name to false.
+
 
 Still to do
 -----------

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -30,3 +30,4 @@
 - include: site.yml
   site: "{{nginx_default_site_name}}"
   template: default-site
+  when: nginx_default_site_name is defined and nginx_default_site_name


### PR DESCRIPTION
Please check first, I am not sure if I understood it correctly.
But even with a site with a server_name, the default config was used and returned 502s 
So I added this condition to avoid defaults.
