### PR TITLE
No robots allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Callable tasks:
 
 - `site`: Creates and enables (or removes) a nginx site
 
+The callable task can be customized::
+- `block_robots`: If set to true, nginx loads a generic robots.txt on /robot.txt that disallows all robots to access the site. Good for test sites. Default is off.
+
 
 Usage
 -----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ nginx_enabled_sites_dir: "{{nginx_conf_dir}}/sites-enabled"
 nginx_create_status_site: yes
 nginx_create_default_site: yes
 nginx_default_site_name: default
+block_robots: false
 
 
 # SSL

--- a/files/no_robots.txt
+++ b/files/no_robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,6 +22,7 @@
     dest: "{{nginx_conf_dir}}/{{item}}"
   with_items:
     - mime.types
+    - no_robots.txt
   notify: restart nginx
   tags:
     - nginx

--- a/templates/static-site
+++ b/templates/static-site
@@ -19,6 +19,13 @@ server {
 	root {{document_root}};
 	expires max;  # Cache assets indefinitely
 
+{% if block_robots %}
+	location = /robots.txt { 
+	    access_log off; 
+	    alias {{ nginx_conf_dir }}/no_robots.txt;
+	}
+{% endif %}
+
 	# Ignore files starting with `~`
 	location ~ ^~*$ {
 		return 404;

--- a/test.yml
+++ b/test.yml
@@ -25,6 +25,17 @@
       sudo: yes
       apt: update_cache=yes
 
+  post_tasks:
+    # Produce a default site pointing to the shared folder
+    - include: tasks/site.yml
+      site: www
+      port: 80
+      block_robots: true
+      server_name: 192.168.33.20
+      access_log: /var/www/site/~access.log
+      error_log: /var/www/site/~error.log
+      document_root: /var/www/site
+
   roles:
     - '.'    # The current directory itself is the role
 


### PR DESCRIPTION
This adds the option that a site declares it wants a robots.txt that blocks all robots.
It will always install the file no_robots.txt to /etc/nginx, because it does not know whether a site might want it.
The default is off, so no_robots.txt would not be used.
